### PR TITLE
historyMode #25 #履歴取得を一般ユーザーモードと管理者モードに分離

### DIFF
--- a/attendance_system/templates/admin_history.html
+++ b/attendance_system/templates/admin_history.html
@@ -1,45 +1,106 @@
 <!DOCTYPE html>
 <html lang="ja">
+
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>出退勤管理システム | 全ユーザーの出勤・退勤履歴</title>
     <style>
-        body { font-family: Arial, sans-serif; margin: 20px; }
-        table { width: 100%; border-collapse: collapse; margin-bottom: 20px; }
-        table, th, td { border: 1px solid black; }
-        th, td { padding: 10px; text-align: left; }
-        th { background-color: #f2f2f2; }
-        h1 { text-align: center; }
+        body {
+            font-family: Arial, sans-serif;
+            margin: 20px;
+        }
+
+        table {
+            width: 100%;
+            border-collapse: collapse;
+            margin-bottom: 20px;
+        }
+
+        table,
+        th,
+        td {
+            border: 1px solid black;
+        }
+
+        th,
+        td {
+            padding: 10px;
+            text-align: left;
+        }
+
+        th {
+            background-color: #f2f2f2;
+        }
+
+        h1 {
+            text-align: center;
+        }
+
+        #stamp {
+            text-decoration: none;
+            display: block;
+            width: 250px;
+            padding: 10px 0;
+            margin-left: auto;
+            background: #ffbf00;
+            color: #140e00;
+            text-align: center;
+        }
+
+        @media screen and (min-width: 480px) {
+            #stamp {
+                font-size: large;
+                position: absolute;
+                right: 0px;
+                top: -10px;
+            }
+        }
+
+        #stamp:hover {
+            background: #ffae00;
+        }
+
+        #title {
+            position: relative;
+        }
     </style>
 </head>
+
 <body>
     <h1>Y-topia 出退勤管理システム</h1>
-    <h2>全ユーザーの出勤・退勤履歴</h2>
-    
+    <div id="title">
+        <h2>全ユーザーの出勤・退勤履歴</h2>
+        <p><a href="{{ url_for('history_defalt') }}" id="stamp">自分の履歴</a></p>
+    </div>
+
+
     <table>
         <thead>
             <tr>
                 <th>ユーザー名</th>
                 <th>出勤時間</th>
                 <th>退勤時間</th>
+                <th>活動場所</th>
             </tr>
         </thead>
         <tbody>
             {% for record in records %}
-                <tr>
-                    <td>{{ record[0] }}</td>  <!-- ユーザー名 -->
-                    <td>{{ record[1] if record[1] else '---' }}</td>  <!-- 出勤時間 -->
-                    <td>{{ record[2] if record[2] else '---' }}</td>  <!-- 退勤時間 -->
-                </tr>
+            <tr>
+                <td>{{ record[0] }}</td> <!-- ユーザー名 -->
+                <td>{{ record[1] if record[1] else '---' }}</td> <!-- 出勤時間 -->
+                <td>{{ record[2] if record[2] else '---' }}</td> <!-- 退勤時間 -->
+                <td>{{ record[3] if record[3] else '---' }}</td> <!-- 活動場所 -->
+            </tr>
             {% else %}
-                <tr>
-                    <td colspan="3">履歴がありません。</td>
-                </tr>
+            <tr>
+                <td colspan="3">履歴がありません。</td>
+            </tr>
             {% endfor %}
         </tbody>
     </table>
 
     <p><a href="{{ url_for('index') }}">戻る</a></p>
 </body>
+
 </html>

--- a/attendance_system/templates/admin_history.html
+++ b/attendance_system/templates/admin_history.html
@@ -74,6 +74,7 @@
         <p><a href="{{ url_for('history_defalt') }}" id="stamp">自分の履歴</a></p>
     </div>
 
+    <p style="text-align: right"><a href="{{ url_for('index') }}">ホームへ戻る</a></p>
 
     <table>
         <thead>
@@ -100,7 +101,7 @@
         </tbody>
     </table>
 
-    <p><a href="{{ url_for('index') }}">戻る</a></p>
+    <p><a href="{{ url_for('index') }}">ホームへ戻る</a></p>
 </body>
 
 </html>

--- a/attendance_system/templates/history.html
+++ b/attendance_system/templates/history.html
@@ -1,22 +1,81 @@
 <!DOCTYPE html>
 <html lang="ja">
+
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>出退勤管理システム | 出勤・退勤履歴</title>
     <style>
-        body { font-family: Arial, sans-serif; margin: 20px; }
-        table { width: 100%; border-collapse: collapse; margin-bottom: 20px; }
-        table, th, td { border: 1px solid black; }
-        th, td { padding: 10px; text-align: left; }
-        th { background-color: #f2f2f2; }
-        h1 { text-align: center; }
+        body {
+            font-family: Arial, sans-serif;
+            margin: 20px;
+        }
+
+        table {
+            width: 100%;
+            border-collapse: collapse;
+            margin-bottom: 20px;
+        }
+
+        table,
+        th,
+        td {
+            border: 1px solid black;
+        }
+
+        th,
+        td {
+            padding: 10px;
+            text-align: left;
+        }
+
+        th {
+            background-color: #f2f2f2;
+        }
+
+        h1 {
+            text-align: center;
+        }
+
+        #stamp {
+            text-decoration: none;
+            display: block;
+            width: 250px;
+            padding: 10px 0;
+            margin-left: auto;
+            background: #ffbf00;
+            color: #140e00;
+            text-align: center;
+        }
+
+        @media screen and (min-width: 480px) {
+            #stamp {
+                font-size: large;
+                position: absolute;
+                right: 0px;
+                top: -10px;
+            }
+        }
+
+        #stamp:hover {
+            background: #ffae00;
+        }
+
+        #title {
+            position: relative;
+        }
     </style>
 </head>
+
 <body>
     <h1>Y-topia 出退勤管理システム</h1>
-    <h2>出勤・退勤履歴</h2>
-    
+    <div id="title">
+        <h2>出勤・退勤履歴</h2>
+        {% if isAdmin %}
+        <p><a href="{{ url_for('history_admin') }}" id="stamp">全ユーザーの履歴</a></p>
+        {% endif %}
+    </div>
+
     <table>
         <thead>
             <tr>
@@ -28,20 +87,21 @@
         </thead>
         <tbody>
             {% for record in records %}
-                <tr>
-                    <td>{{ record[0] }}</td>  <!-- ユーザー名 -->
-                    <td>{{ record[1] if record[1] else '---' }}</td>  <!-- 出勤時間 -->
-                    <td>{{ record[2] if record[2] else '---' }}</td>  <!-- 退勤時間 -->
-                    <td>{{ record[3] if record[3] else '---' }}</td>  <!-- 活動場所 -->
-                </tr>
+            <tr>
+                <td>{{ record[0] }}</td> <!-- ユーザー名 -->
+                <td>{{ record[1] if record[1] else '---' }}</td> <!-- 出勤時間 -->
+                <td>{{ record[2] if record[2] else '---' }}</td> <!-- 退勤時間 -->
+                <td>{{ record[3] if record[3] else '---' }}</td> <!-- 活動場所 -->
+            </tr>
             {% else %}
-                <tr>
-                    <td colspan="3">履歴がありません。</td>
-                </tr>
+            <tr>
+                <td colspan="3">履歴がありません。</td>
+            </tr>
             {% endfor %}
         </tbody>
     </table>
 
     <p><a href="{{ url_for('index') }}">戻る</a></p>
 </body>
+
 </html>

--- a/attendance_system/templates/history.html
+++ b/attendance_system/templates/history.html
@@ -76,6 +76,8 @@
         {% endif %}
     </div>
 
+    <p style="text-align: right"><a href="{{ url_for('index') }}">ホームへ戻る</a></p>
+
     <table>
         <thead>
             <tr>
@@ -101,7 +103,7 @@
         </tbody>
     </table>
 
-    <p><a href="{{ url_for('index') }}">戻る</a></p>
+    <p><a href="{{ url_for('index') }}">ホームへ戻る</a></p>
 </body>
 
 </html>

--- a/attendance_system/templates/index.html
+++ b/attendance_system/templates/index.html
@@ -117,7 +117,7 @@
     <p>※学外アクセスの場合は打刻できません※</p>
 
     <!-- 出勤・退勤履歴へのリンク -->
-    <p><a href="{{ url_for('history') }}">出勤・退勤履歴</a></p>
+    <p><a href="{{ url_for('history_defalt') }}">出勤・退勤履歴</a></p>
 
     <p><a href="{{ url_for('isWorking') }}">研C315に出勤中のメンバー</a></p>
 


### PR DESCRIPTION
# 出退勤の履歴表示を一般ユーザーモードと管理者モードに分離しました(#25)
今まで、管理者権限を持つユーザーが出退勤の履歴表示をした場合、全ユーザーの履歴が表示されていた(管理者モード)のを自分の履歴のみがデフォルトで表示される(一般ユーザーモード)ように改善しました。
その上で、デフォルトページ上部に全ユーザーの履歴を表示する(管理者モード)ボタンを設置しました。(以下の画像参照)
![スクリーンショット 2025-02-23 141644](https://github.com/user-attachments/assets/8173f461-11e8-40be-8166-51054f3c7c81)
全ユーザーの履歴を表示するページでは、ホーム画面へ戻るリンクの他に、自分の履歴を表示する(一般ユーザーモード)デフォルトに飛ぶボタンも設置しました。(以下の画像参照)
![image](https://github.com/user-attachments/assets/3879bf3a-16e2-4429-8661-689b807e3739)

技術内容補足事項
各モードごとにエンドポイントを分けた上で、DBからのデータ取得はモードを引き数として指定してget_history関数が行い、呼び出されたエンドポイントにデータを返す。

このプルリクへのレビューは原則不要ですが、暇があればコードレビューをしてもらえると嬉しいです。
（マージはレビューを待たずに行います）

Close #25 